### PR TITLE
fix: expand context7 MCP server usage to include LangSmith and Crew AI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # Claude Instructions
 
-## LangGraph Queries
-- Always use Context7 MCP server when answering questions about LangGraph
+## Context7 MCP Server Queries
+- Always use Context7 MCP server when answering questions about:
+  - LangGraph
+  - LangSmith
+  - Crew AI
 - This ensures access to the most up-to-date documentation and examples


### PR DESCRIPTION
- Updated CLAUDE.md to specify that context7 MCP server should be used for LangGraph, LangSmith, and Crew AI queries
- Renamed section from 'LangGraph Queries' to 'Context7 MCP Server Queries' for clarity

Fixes #2